### PR TITLE
Implement autoloading for Terser and update Compressor class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,20 +67,44 @@ jobs:
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.1.x.sprockets-4.x"
+          - ruby: 3.1
+            gemfile: "gemfiles/Gemfile.rails-7.2.x.sprockets-4.x"
           # Ruby 3.2.x
-          - ruby: 3.2
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-7.1.x.sprockets-4.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-7.2.x.sprockets-4.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-8.0.x.sprockets-4.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-8.1.x.sprockets-4.x"
           # Ruby 3.3.x
-          - ruby: 3.3
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           - ruby: 3.3
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           - ruby: 3.3
-            gemfile: Gemfile
+            gemfile: "gemfiles/Gemfile.rails-7.1.x.sprockets-4.x"
+          - ruby: 3.3
+            gemfile: "gemfiles/Gemfile.rails-7.2.x.sprockets-4.x"
+          - ruby: 3.3
+            gemfile: "gemfiles/Gemfile.rails-8.0.x.sprockets-4.x"
+          - ruby: 3.3
+            gemfile: "gemfiles/Gemfile.rails-8.1.x.sprockets-4.x"
+          # Ruby 3.4.x
+          - ruby: 3.4
+            gemfile: "gemfiles/Gemfile.rails-7.2.x.sprockets-4.x"
+          - ruby: 3.4
+            gemfile: "gemfiles/Gemfile.rails-8.0.x.sprockets-4.x"
+          - ruby: 3.4
+            gemfile: "gemfiles/Gemfile.rails-8.1.x.sprockets-4.x"
+          # Ruby 4.0.x
+          - ruby: '4.0'
+            gemfile: "gemfiles/Gemfile.rails-7.2.x.sprockets-4.x"
+          - ruby: '4.0'
+            gemfile: "gemfiles/Gemfile.rails-8.0.x.sprockets-4.x"
+          - ruby: '4.0'
+            gemfile: "gemfiles/Gemfile.rails-8.1.x.sprockets-4.x"
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
             gemfile: "gemfiles/Gemfile.rails-5.2.x"
           - ruby: 2.6
             gemfile: "gemfiles/Gemfile.rails-5.2.x.sprockets-4.x"
-          - ruby: 2.6
-            gemfile: "gemfiles/Gemfile.rails-6.0.x.sprockets-4.x"
-          - ruby: 2.6
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           # Ruby 2.7.x
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-5.0.x"
@@ -48,21 +44,13 @@ jobs:
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-5.2.x.sprockets-4.x"
           - ruby: 2.7
-            gemfile: "gemfiles/Gemfile.rails-6.0.x.sprockets-4.x"
-          - ruby: 2.7
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
-          - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           # Ruby 3.0.x
-          - ruby: '3.0'
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           - ruby: '3.0'
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           - ruby: '3.0'
             gemfile: "gemfiles/Gemfile.rails-7.1.x.sprockets-4.x"
           # Ruby 3.1.x
-          - ruby: 3.1
-            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.0.x.sprockets-4.x"
           - ruby: 3.1

--- a/gemfiles/Gemfile.rails-7.2.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-7.2.x.sprockets-4.x
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sprockets_terser_with_source_maps.gemspec
+gemspec path: '..'
+
+gem 'railties', '~> 7.2.0'
+gem 'sprockets', '~> 4.0'
+

--- a/gemfiles/Gemfile.rails-7.2.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-7.2.x.sprockets-4.x
@@ -7,4 +7,3 @@ gemspec path: '..'
 
 gem 'railties', '~> 7.2.0'
 gem 'sprockets', '~> 4.0'
-

--- a/gemfiles/Gemfile.rails-8.0.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-8.0.x.sprockets-4.x
@@ -7,4 +7,3 @@ gemspec path: '..'
 
 gem 'railties', '~> 8.0.0'
 gem 'sprockets', '~> 4.0'
-

--- a/gemfiles/Gemfile.rails-8.0.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-8.0.x.sprockets-4.x
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sprockets_terser_with_source_maps.gemspec
+gemspec path: '..'
+
+gem 'railties', '~> 8.0.0'
+gem 'sprockets', '~> 4.0'
+

--- a/gemfiles/Gemfile.rails-8.1.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-8.1.x.sprockets-4.x
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in sprockets_terser_with_source_maps.gemspec
+gemspec path: '..'
+
+gem 'railties', '~> 8.1.0'
+gem 'sprockets', '~> 4.0'
+

--- a/gemfiles/Gemfile.rails-8.1.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-8.1.x.sprockets-4.x
@@ -7,4 +7,3 @@ gemspec path: '..'
 
 gem 'railties', '~> 8.1.0'
 gem 'sprockets', '~> 4.0'
-

--- a/lib/sprockets_terser_with_source_maps.rb
+++ b/lib/sprockets_terser_with_source_maps.rb
@@ -4,7 +4,6 @@ require 'sprockets'
 require 'sprockets_terser_with_source_maps/version'
 require 'sprockets_terser_with_source_maps/compressor'
 require 'sprockets_terser_with_source_maps/railtie' if defined? Rails::Railtie
-require 'terser'
 
 Sprockets.register_compressor 'application/javascript',
                               :terser_with_source_maps,

--- a/lib/sprockets_terser_with_source_maps/autoload.rb
+++ b/lib/sprockets_terser_with_source_maps/autoload.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SprocketsTerserWithSourceMaps
+  module Autoload # :nodoc:
+    autoload :Terser, 'sprockets_terser_with_source_maps/autoload/terser'
+  end
+end

--- a/lib/sprockets_terser_with_source_maps/autoload/terser.rb
+++ b/lib/sprockets_terser_with_source_maps/autoload/terser.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'terser'
+
+module SprocketsTerserWithSourceMaps
+  module Autoload
+    Terser = ::Terser
+  end
+end

--- a/lib/sprockets_terser_with_source_maps/compressor.rb
+++ b/lib/sprockets_terser_with_source_maps/compressor.rb
@@ -10,8 +10,8 @@ module SprocketsTerserWithSourceMaps
     attr_accessor :logger
 
     def initialize(options = {})
-      @logger = Logger.new($stdout)
-      @logger.level = Logger::INFO
+      @logger = ::Logger.new($stdout)
+      @logger.level = ::Logger::INFO
       @options = options.merge(Rails.application.config.assets.terser.to_h)
       @cache_key = -"Terser:#{Autoload::Terser::VERSION}:#{VERSION}:#{::Sprockets::DigestUtils.digest(@options)}"
       @terser = Autoload::Terser.new(@options)

--- a/lib/sprockets_terser_with_source_maps/compressor.rb
+++ b/lib/sprockets_terser_with_source_maps/compressor.rb
@@ -1,20 +1,35 @@
 # frozen_string_literal: true
 
 require 'sprockets/digest_utils'
-require 'terser/compressor'
+require 'sprockets_terser_with_source_maps/autoload'
 require 'logger'
 
 module SprocketsTerserWithSourceMaps
   # Custom compressor to generate sourcemaps
-  class Compressor < Terser::Compressor
+  class Compressor
     attr_accessor :logger
 
     def initialize(options = {})
       @logger = Logger.new($stdout)
       @logger.level = Logger::INFO
       @options = options.merge(Rails.application.config.assets.terser.to_h)
-      super(@options)
+      @cache_key = -"Terser:#{Autoload::Terser::VERSION}:#{VERSION}:#{::Sprockets::DigestUtils.digest(@options)}"
+      @terser = Autoload::Terser.new(@options)
     end
+
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.call(input)
+      instance.call(input)
+    end
+
+    def self.cache_key
+      instance.cache_key
+    end
+
+    attr_reader :cache_key
 
     def call(input)
       input_options = { source_map: { filename: input[:filename] } }

--- a/lib/sprockets_terser_with_source_maps/compressor.rb
+++ b/lib/sprockets_terser_with_source_maps/compressor.rb
@@ -12,6 +12,8 @@ module SprocketsTerserWithSourceMaps
     def initialize(options = {})
       @logger = ::Logger.new($stdout)
       @logger.level = ::Logger::INFO
+
+      options[:comments] ||= :none
       @options = options.merge(Rails.application.config.assets.terser.to_h)
       @cache_key = -"Terser:#{Autoload::Terser::VERSION}:#{VERSION}:#{::Sprockets::DigestUtils.digest(@options)}"
       @terser = Autoload::Terser.new(@options)

--- a/spec/autoload_spec.rb
+++ b/spec/autoload_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+RSpec.describe SprocketsTerserWithSourceMaps::Autoload do
+  describe 'deferred loading of Terser' do
+    it 'does not require terser when Rails initializes' do
+      script = <<~RUBY
+        require 'bundler/setup'
+        require 'sprockets/railtie'
+        require 'sprockets_terser_with_source_maps'
+
+        ENV['RAILS_ENV'] = 'test'
+        require 'rails_app/config/environment'
+
+        if defined?(::Terser)
+          abort 'FAIL: Terser was eagerly loaded during Rails initialization'
+        end
+
+        # Trigger the autoload by referencing the constant
+        klass = SprocketsTerserWithSourceMaps::Autoload::Terser
+
+        unless defined?(::Terser)
+          abort 'FAIL: Terser was not loaded after referencing Autoload::Terser'
+        end
+
+        unless klass == ::Terser
+          abort 'FAIL: Autoload::Terser does not match ::Terser'
+        end
+
+        puts 'OK'
+      RUBY
+
+      output, status = Bundler.with_unbundled_env do
+        Open3.capture2e(RbConfig.ruby, '-I', File.expand_path('..', __dir__), '-I', __dir__, '-e', script)
+      end
+
+      expect(status).to be_success, "Subprocess failed:\n#{output}"
+      expect(output.strip).to eq('OK')
+    end
+  end
+
+  it 'aliases Autoload::Terser to ::Terser' do
+    expect(SprocketsTerserWithSourceMaps::Autoload::Terser).to eq(Terser)
+  end
+end

--- a/spec/autoload_spec.rb
+++ b/spec/autoload_spec.rb
@@ -31,12 +31,15 @@ RSpec.describe SprocketsTerserWithSourceMaps::Autoload do
         puts 'OK'
       RUBY
 
-      output, status = Bundler.with_unbundled_env do
-        Open3.capture2e(RbConfig.ruby, '-I', File.expand_path('..', __dir__), '-I', __dir__, '-e', script)
+      gemfile = ENV['BUNDLE_GEMFILE'] || File.expand_path('../../Gemfile', __dir__)
+      env = { 'BUNDLE_GEMFILE' => gemfile }
+
+      stdout, stderr, status = Bundler.with_unbundled_env do
+        Open3.capture3(env, RbConfig.ruby, '-I', File.expand_path('..', __dir__), '-I', __dir__, '-e', script)
       end
 
-      expect(status).to be_success, "Subprocess failed:\n#{output}"
-      expect(output.strip).to eq('OK')
+      expect(status).to be_success, "Subprocess failed:\n#{stderr}"
+      expect(stdout.strip).to eq('OK')
     end
   end
 

--- a/sprockets_terser_with_source_maps.gemspec
+++ b/sprockets_terser_with_source_maps.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'terser', '~> 1.2'
 
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'railties', '>= 4.2'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '>= 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
 


### PR DESCRIPTION
This pull request updates the CI matrix and introduces support for newer Rails and Ruby versions, while also refactoring how the Terser dependency is loaded to enable deferred loading. Additionally, the compressor implementation is updated for better modularity, and new tests are added to ensure Terser is only loaded when needed.

**CI and Rails/Ruby version support:**
- Expanded the CI matrix in `.github/workflows/ci.yml` to include Rails 7.2.x, 8.0.x, and 8.1.x with Sprockets 4.x for Ruby versions 3.1 through 4.0, and removed support for older Rails/Sprockets combinations. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-L36) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL50-R95)
- Added new Gemfiles: `Gemfile.rails-7.2.x.sprockets-4.x`, `Gemfile.rails-8.0.x.sprockets-4.x`, and `Gemfile.rails-8.1.x.sprockets-4.x` to support the new Rails versions in tests. [[1]](diffhunk://#diff-2f409140ce40e7fe59b480ce283db50aae2f47dd3921165e30575368fa5442c2R1-R10) [[2]](diffhunk://#diff-4ebf216267328b2f180aeecf89e094cde712bff6a3beecb6876cd5c58259ddf1R1-R10) [[3]](diffhunk://#diff-817d2de0551bc1af4d4819a236cfd6d6515ff048258199142fa632c74f3f3789R1-R10)

**Terser dependency loading and compressor refactor:**
- Refactored Terser loading to use an autoload mechanism, deferring the loading of the `terser` gem until it is actually needed, improving Rails initialization performance. [[1]](diffhunk://#diff-0f10f6f8ffedfc8760ee8db68e81da05325a3371d06f25df1e84832f91dd0517L7) [[2]](diffhunk://#diff-9d3dd4d8f18f2894ce7f9ef4773e68236e1629e1e9994f7016e5d8625e5df712R1-R7) [[3]](diffhunk://#diff-2e950f675830714284471bb656f3102124d964c5141e1e44ac232fc3712400a8R1-R9)
- Updated `Compressor` to no longer inherit from `Terser::Compressor`, instead instantiating a Terser object via the new autoload module, and added singleton accessors for easier and more efficient use.

**Testing and development dependencies:**
- Added a new RSpec test to verify that Terser is not eagerly loaded during Rails initialization and is properly autoloaded when referenced.
- Minor gemspec updates: added `ostruct` as a development dependency and relaxed the minimum version for `rake`.